### PR TITLE
:white_check_mark: fix book repository test

### DIFF
--- a/book-market/build.gradle.kts
+++ b/book-market/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test:5.5.2")
 	testImplementation("io.mockk:mockk:1.12.0")
+	testImplementation("org.assertj:assertj-core:3.21.0")
 
 	runtimeOnly("org.postgresql:postgresql")
 }

--- a/book-market/src/test/kotlin/com/amycardoso/bookmarket/helper/ModelBuilderHelper.kt
+++ b/book-market/src/test/kotlin/com/amycardoso/bookmarket/helper/ModelBuilderHelper.kt
@@ -41,7 +41,7 @@ fun buildPurchase(
 fun buildBook(
     id: Int? = null,
     name: String = "book name",
-    price: BigDecimal = BigDecimal(0).setScale(2, RoundingMode.HALF_UP).stripTrailingZeros(),
+    price: BigDecimal = BigDecimal(Math.random()).setScale(2, RoundingMode.HALF_UP),
     customer: Customer? = null,
     status: BookStatus = BookStatus.ACTIVE
 ) = Book (

--- a/book-market/src/test/kotlin/com/amycardoso/bookmarket/repository/BookRepositoryTest.kt
+++ b/book-market/src/test/kotlin/com/amycardoso/bookmarket/repository/BookRepositoryTest.kt
@@ -4,8 +4,8 @@ import com.amycardoso.bookmarket.enums.BookStatus
 import com.amycardoso.bookmarket.helper.buildBook
 import com.amycardoso.bookmarket.helper.buildCustomer
 import com.amycardoso.bookmarket.model.Book
-import com.amycardoso.bookmarket.model.Customer
 import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -44,7 +44,9 @@ class BookRepositoryTest {
         val pageableBooks = PageImpl<Book>(fakeBooks, pageable, fakeBooks.size.toLong())
 
         val books = bookRepository.findByStatus(deletedStatus, pageable);
-        Assertions.assertEquals(pageableBooks, books)
+
+        assertThat(pageableBooks).usingRecursiveFieldByFieldElementComparatorIgnoringFields("price")
+            .isEqualTo(books);
     }
 
 }


### PR DESCRIPTION
A test from the book repository was failing because of BigDecimal comparison. Since the goal is just to assert if the list of books returned was the one expected, the price can be ignored. So I am using a recursive field by field comparison on all fields (including inherited fields) except the price field.